### PR TITLE
Fix InstagramUploadPhotoRequest still returning StatusResult

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramUploadPhotoRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramUploadPhotoRequest.java
@@ -46,7 +46,7 @@ import lombok.extern.log4j.Log4j;
 @AllArgsConstructor
 @NoArgsConstructor
 @RequiredArgsConstructor
-public class InstagramUploadPhotoRequest extends InstagramRequest<StatusResult> {
+public class InstagramUploadPhotoRequest extends InstagramRequest<InstagramConfigurePhotoResult> {
 
     @NonNull
     private File imageFile;
@@ -66,7 +66,7 @@ public class InstagramUploadPhotoRequest extends InstagramRequest<StatusResult> 
     }
     
     @Override
-    public StatusResult execute() throws ClientProtocolException, IOException {
+    public InstagramConfigurePhotoResult execute() throws ClientProtocolException, IOException {
         
         if (uploadId == null) {
             uploadId = String.valueOf(System.currentTimeMillis());
@@ -149,8 +149,8 @@ public class InstagramUploadPhotoRequest extends InstagramRequest<StatusResult> 
     }
 
     @Override
-    public StatusResult parseResult(int statusCode, String content) {
-        return parseJson(statusCode, content, StatusResult.class);
+    public InstagramConfigurePhotoResult parseResult(int statusCode, String content) {
+        return parseJson(statusCode, content, InstagramConfigurePhotoResult.class);
     }
 
 }


### PR DESCRIPTION
Hi, This is my first time contributing to anything so forgive me if i messed this up.
InstagramUploadPhotoRequest still returns StatusResult when i tried the snapshot version.
I just changed StatusResult to InstagramConfigurePhotoResult and I was able to do what I was hoping to achieve, get the media code.