### PR TITLE
TimelineFeedRequest changes to work with FeedResult

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramTimelineFeedRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramTimelineFeedRequest.java
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.brunocvcunha.instagram4j.requests;
+import org.brunocvcunha.instagram4j.requests.InstagramGetRequest;
+import org.brunocvcunha.instagram4j.requests.payload.InstagramFeedResult;
 import lombok.SneakyThrows;
 
 /**

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramTimelineFeedRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramTimelineFeedRequest.java
@@ -14,9 +14,6 @@
  * limitations under the License.
  */
 package org.brunocvcunha.instagram4j.requests;
-
-import org.brunocvcunha.instagram4j.requests.payload.StatusResult;
-
 import lombok.SneakyThrows;
 
 /**
@@ -25,9 +22,16 @@ import lombok.SneakyThrows;
  * @author Bruno Candido Volpato da Cunha
  *
  */
-public class InstagramTimelineFeedRequest extends InstagramGetRequest<StatusResult> {
+public class InstagramTimelineFeedRequest extends InstagramGetRequest<InstagramFeedResult> {
 
     private String maxId;
+    
+    public InstagramTimelineFeedRequest() {
+    }
+
+    public InstagramTimelineFeedRequest(String maxId) {
+        this.maxId = maxId;
+    }
     
     @Override
     public String getUrl() {
@@ -45,9 +49,12 @@ public class InstagramTimelineFeedRequest extends InstagramGetRequest<StatusResu
     }
 
     @Override
-    @SneakyThrows
-    public StatusResult parseResult(int statusCode, String content) {
-        return parseJson(statusCode, content, StatusResult.class);
+    public InstagramFeedResult parseResult(int statusCode, String content) {
+        try {
+            return this.parseJson(statusCode, content, InstagramFeedResult.class);
+        } catch (Throwable var4) {
+            throw var4;
+        }
     }
 
 }

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramTimelineFeedRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramTimelineFeedRequest.java
@@ -13,8 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.brunocvcunha.instagram4j.requests;
+
 import org.brunocvcunha.instagram4j.requests.InstagramGetRequest;
 import org.brunocvcunha.instagram4j.requests.payload.InstagramFeedResult;
+
 import lombok.SneakyThrows;
 
 /**


### PR DESCRIPTION
InstagramTimeFeedRequest was working with StatusResult. It was changed to work with InstagramFeedResult. This way it could be used to fetch Timeline Feed