### PR TITLE
Updated get media info request as instagram changed it from post to get

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetMediaInfoRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetMediaInfoRequest.java
@@ -36,29 +36,13 @@ import lombok.extern.log4j.Log4j;
  */
 @AllArgsConstructor
 @Log4j
-public class InstagramGetMediaInfoRequest extends InstagramPostRequest<InstagramGetMediaInfoResult> {
+public class InstagramGetMediaInfoRequest extends InstagramGetRequest<InstagramGetMediaInfoResult> {
 
     private long mediaId;
 
     @Override
     public String getUrl() {
         return "media/" + mediaId + "/info/";
-    }
-
-    @Override
-    @SneakyThrows
-    public String getPayload() {
-        ObjectMapper mapper = new ObjectMapper();
-        
-        Map<String, Object> payloadMap = new LinkedHashMap<>();
-        payloadMap.put("_uuid", api.getUuid());
-        payloadMap.put("_uid", api.getUserId());
-        payloadMap.put("_csrftoken", api.getOrFetchCsrf());
-        payloadMap.put("media_id", mediaId);
-        
-        String payloadJson = mapper.writeValueAsString(payloadMap);
-
-        return payloadJson;
     }
 
     @Override


### PR DESCRIPTION
While working with retrieving media from Instagram I noticed that InstagramGetMediaInfoRequest always results in 405 (method not allowed) code. After some research in similar JS/PHP libraries I found out that Instagram switched this method from post to get format. I specifically referenced this [commit ](https://github.com/mgp25/Instagram-API/commit/b7f1d9812d4dbca5a3eee8f5c45cfcd1c8240775#diff-d8d5c3f8c67f59dbc95eded8c6ed5b20 )where this change is most obvious. 