### PR TITLE
[NOT READY FOR MERGE] the direct messaging update

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramApprovePendingThreadRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramApprovePendingThreadRequest.java
@@ -1,0 +1,47 @@
+package org.brunocvcunha.instagram4j.requests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.brunocvcunha.instagram4j.requests.InstagramGetRequest;
+import org.brunocvcunha.instagram4j.requests.InstagramPostRequest;
+import org.brunocvcunha.instagram4j.requests.payload.StatusResult;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class InstagramApprovePendingThreadRequest extends InstagramPostRequest<StatusResult> {
+
+    private String threadId;
+
+    @Override
+    public String getUrl() {
+
+        String baseUrl = "direct_v2/threads/" + threadId + "/approve/";
+        return baseUrl;
+    }
+
+    @Override
+    @SneakyThrows
+    public String getPayload() {
+
+        Map<String, Object> approveMap = new LinkedHashMap<>();
+        approveMap.put("_uuid", api.getUuid());
+        approveMap.put("_csrftoken", api.getOrFetchCsrf());
+        approveMap.put("_uid", api.getUserId());
+
+        ObjectMapper mapper = new ObjectMapper();
+        String payloadJson = mapper.writeValueAsString(approveMap);
+
+        return payloadJson;
+    }
+
+    @Override
+    @SneakyThrows
+    public StatusResult parseResult(int statusCode, String content) {
+        return parseJson(statusCode, content, StatusResult.class);
+    }
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDeclinePendingThreadRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDeclinePendingThreadRequest.java
@@ -1,0 +1,46 @@
+package org.brunocvcunha.instagram4j.requests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.brunocvcunha.instagram4j.requests.InstagramPostRequest;
+import org.brunocvcunha.instagram4j.requests.payload.StatusResult;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class InstagramDeclinePendingThreadRequest extends InstagramPostRequest<StatusResult> {
+
+    private String threadId;
+
+    @Override
+    public String getUrl() {
+
+        String baseUrl = "direct_v2/threads/" + threadId + "/decline/";
+        return baseUrl;
+    }
+
+    @Override
+    @SneakyThrows
+    public String getPayload() {
+
+        Map<String, Object> approveMap = new LinkedHashMap<>();
+        approveMap.put("_uuid", api.getUuid());
+        approveMap.put("_csrftoken", api.getOrFetchCsrf());
+        approveMap.put("_uid", api.getUserId());
+
+        ObjectMapper mapper = new ObjectMapper();
+        String payloadJson = mapper.writeValueAsString(approveMap);
+
+        return payloadJson;
+    }
+
+    @Override
+    @SneakyThrows
+    public StatusResult parseResult(int statusCode, String content) {
+        return parseJson(statusCode, content, StatusResult.class);
+    }
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDirectShareRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDirectShareRequest.java
@@ -110,6 +110,7 @@ public class InstagramDirectShareRequest extends InstagramRequest<StatusResult> 
             // this is the same array formatting magic as with the recipients
             String link_urls = "";
             link_urls = "\"" + String.join("\",\"", this.link_urls.toArray(new String[0])) + "\"";
+            link_urls = "[" + link_urls + "]";
 
             StringBody linkUrlsBody = new StringBody(link_urls, ContentType.MULTIPART_FORM_DATA);
             builder.addPart("link_urls", linkUrlsBody);

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDirectShareRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramDirectShareRequest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright (C) 2016 Bruno Candido Volpato da Cunha (brunocvcunha@gmail.com)
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,13 +15,9 @@
  */
 package org.brunocvcunha.instagram4j.requests;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.log4j.Log4j;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPost;
@@ -31,193 +27,221 @@ import org.brunocvcunha.instagram4j.InstagramConstants;
 import org.brunocvcunha.instagram4j.requests.payload.StatusResult;
 import org.brunocvcunha.instagram4j.util.InstagramGenericUtil;
 
-import lombok.Builder;
-import lombok.NonNull;
-import lombok.extern.log4j.Log4j;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Direct-share request.
- * 
- * @author Evgeny Bondarenko (evgbondarenko@gmail.com)
  *
+ * @author Evgeny Bondarenko (evgbondarenko@gmail.com)
  */
 @Log4j
 @Builder(builderClassName = "DirectShareRequestBuilder", builderMethodName = "internalBuilder")
 public class InstagramDirectShareRequest extends InstagramRequest<StatusResult> {
-	@NonNull
-	private ShareType shareType;
-	/**
-	 * List of recipients IDs (i.e. "1234567890")
-	 */
-	private List<String> recipients;
-	/**
-	 * The thread ID to share to
-	 */
-	private String threadId;
-	/**
-	 * The media ID in instagram's internal format (ie "223322332233_22332").
-	 */
-	private String mediaId;
-	private String message;
+    @NonNull
+    private ShareType shareType;
+    /**
+     * List of recipients IDs (i.e. "1234567890")
+     */
+    private List<String> recipients;
+    /**
+     * The thread ID to share to
+     */
+    private String threadId;
+    /**
+     * The media ID in instagram's internal format (ie "223322332233_22332").
+     */
+    private String mediaId;
+    private String message;
+    private List<String> link_urls;
+    private String link_text;
 
-	@Override
-	public String getUrl() throws IllegalArgumentException {
-		String result;
-		switch (shareType) {
-		case MESSAGE:
-			result = "direct_v2/threads/broadcast/text/";
-			break;
-		case MEDIA:
-			result = "direct_v2/threads/broadcast/media_share/?media_type=photo";
-			break;
-		default:
-			throw new IllegalArgumentException("Invalid shareType parameter value: " + shareType);
-		}
-		return result;
-	}
+    @Override
+    public String getUrl() throws IllegalArgumentException {
+        String result;
+        switch (shareType) {
+            case MESSAGE:
+                result = "direct_v2/threads/broadcast/text/";
+                break;
+            case MEDIA:
+                result = "direct_v2/threads/broadcast/media_share/?media_type=photo";
+                break;
+            // note: the api *does* support multiple links per message, though that is not compatible with the current data structures
+            // please don't ask me how combined messages work (i.e. a link between other text)
+            case LINK:
+                result = "direct_v2/threads/broadcast/link/";
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid shareType parameter value: " + shareType);
+        }
+        return result;
+    }
 
-	@Override
-	public String getMethod() {
-		return "POST";
-	}
+    @Override
+    public String getMethod() {
+        return "POST";
+    }
 
-	@Override
-	public StatusResult execute() throws ClientProtocolException, IOException {
-		String recipients = "";
-		if (this.recipients != null) {
-			recipients = "\"" + String.join("\",\"", this.recipients.toArray(new String[0])) + "\"";
-		}
-		
-		List<Map<String, String>> data = new ArrayList<Map<String, String>>();
+    @Override
+    public StatusResult execute() throws ClientProtocolException, IOException {
+        String recipients = "";
+        if (this.recipients != null) {
+            recipients = "\"" + String.join("\",\"", this.recipients.toArray(new String[0])) + "\"";
+        }
 
-		Map<String, String> map = new HashMap<String, String>();
-		if (shareType == ShareType.MEDIA) {
-			map.put("type", "form-data");
-			map.put("name", "media_id");
-			map.put("data", mediaId);
-			data.add(map);
-		}
+        List<Map<String, String>> data = new ArrayList<Map<String, String>>();
 
-		map = map.size() > 0 ? new HashMap<String, String>() : map;
-		map.put("type", "form-data");
-		map.put("name", "recipient_users");
-		map.put("data", "[[" + recipients + "]]");
-		data.add(map);
+        Map<String, String> map = new HashMap<String, String>();
+        if (shareType == ShareType.MEDIA) {
+            map.put("type", "form-data");
+            map.put("name", "media_id");
+            map.put("data", mediaId);
+            data.add(map);
+        }
 
-		map = new HashMap<String, String>();
-		map.put("type", "form-data");
-		map.put("name", "client_context");
-		map.put("data", InstagramGenericUtil.generateUuid(true));
-		data.add(map);
+        if (shareType == ShareType.LINK) {
+            String link_urls = "";
+            link_urls = "\"" + String.join("\",\"", this.link_urls.toArray(new String[0])) + "\"";
+            map.put("type", "form-data");
+            map.put("name", "link_urls");
+            map.put("data", "[" + link_urls + "]");
+            data.add(map);
+            map = new HashMap<>();
+            map.put("name", "link_text");
+            map.put("data", link_text);
+            data.add(map);
+        }
 
-		map = new HashMap<String, String>();
-		map.put("type", "form-data");
-		map.put("name", "thread_ids");
-		map.put("data", "[" + (threadId != null ? threadId : "") + "]");
-		data.add(map);
+        map = map.size() > 0 ? new HashMap<String, String>() : map;
+        map.put("type", "form-data");
+        map.put("name", "recipient_users");
+        map.put("data", "[[" + recipients + "]]");
+        data.add(map);
 
-		map = new HashMap<String, String>();
-		map.put("type", "form-data");
-		map.put("name", "text");
-		map.put("data", message == null ? "" : message);
-		data.add(map);
+        map = new HashMap<String, String>();
+        map.put("type", "form-data");
+        map.put("name", "client_context");
+        map.put("data", InstagramGenericUtil.generateUuid(true));
+        data.add(map);
 
-		HttpPost post = createHttpRequest();
-		post.setEntity(new ByteArrayEntity(buildBody(data, api.getUuid()).getBytes(StandardCharsets.UTF_8)));
+        map = new HashMap<String, String>();
+        map.put("type", "form-data");
+        map.put("name", "thread_ids");
+        map.put("data", "[" + (threadId != null ? threadId : "") + "]");
+        data.add(map);
 
-		try (CloseableHttpResponse response = api.getClient().execute(post)) {
-			api.setLastResponse(response);
+        map = new HashMap<String, String>();
+        map.put("type", "form-data");
+        map.put("name", "text");
+        map.put("data", message == null ? "" : message);
+        data.add(map);
 
-			int resultCode = response.getStatusLine().getStatusCode();
-			String content = EntityUtils.toString(response.getEntity());
+        HttpPost post = createHttpRequest();
+        post.setEntity(new ByteArrayEntity(buildBody(data, api.getUuid()).getBytes(StandardCharsets.UTF_8)));
 
-			log.info("Direct-share request result: " + resultCode + ", " + content);
+        try (CloseableHttpResponse response = api.getClient().execute(post)) {
+            api.setLastResponse(response);
 
-			post.releaseConnection();
+            int resultCode = response.getStatusLine().getStatusCode();
+            String content = EntityUtils.toString(response.getEntity());
 
-			StatusResult result = parseResult(resultCode, content);
+            log.info("Direct-share request result: " + resultCode + ", " + content);
 
-			return result;
-		}
-	}
+            post.releaseConnection();
 
-	@Override
-	public StatusResult parseResult(int resultCode, String content) {
-		return parseJson(resultCode, content, StatusResult.class);
-	}
+            StatusResult result = parseResult(resultCode, content);
 
-	protected HttpPost createHttpRequest() {
-		String url = InstagramConstants.API_URL + getUrl();
-		log.info("Direct-share URL: " + url);
+            return result;
+        }
+    }
 
-		HttpPost post = new HttpPost(url);
-		post.addHeader("User-Agent", InstagramConstants.USER_AGENT);
-		post.addHeader("Connection", "keep-alive");
-		post.addHeader("Proxy-Connection", "keep-alive");
-		post.addHeader("Accept", "*/*");
-		post.addHeader("Content-Type", "multipart/form-data; boundary=" + api.getUuid());
-		post.addHeader("Accept-Language", "en-US");
-		return post;
-	}
+    @Override
+    public StatusResult parseResult(int resultCode, String content) {
+        return parseJson(resultCode, content, StatusResult.class);
+    }
 
-	protected String buildBody(List<Map<String, String>> bodies, String boundary) {
-		StringBuilder sb = new StringBuilder();
-		String newLine = "\r\n";
-		for (Map<String, String> b : bodies) {
-			sb.append("--").append(boundary).append(newLine).append("Content-Disposition: ").append(b.get("type"))
-					.append("; name=\"").append(b.get("name")).append("\"").append(newLine).append(newLine)
-					.append(b.get("data")).append(newLine);
-		}
-		sb.append("--").append(boundary).append("--");
-		String body = sb.toString();
+    protected HttpPost createHttpRequest() {
+        String url = InstagramConstants.API_URL + getUrl();
+        log.info("Direct-share URL: " + url);
 
-		log.debug("Direct-share message body: " + body);
-		return body;
-	}
+        HttpPost post = new HttpPost(url);
+        post.addHeader("User-Agent", InstagramConstants.USER_AGENT);
+        post.addHeader("Connection", "keep-alive");
+        post.addHeader("Proxy-Connection", "keep-alive");
+        post.addHeader("Accept", "*/*");
+        post.addHeader("Content-Type", "multipart/form-data; boundary=" + api.getUuid());
+        post.addHeader("Accept-Language", "en-US");
+        return post;
+    }
 
-	protected void init() {
-		switch (shareType) {
-		case MEDIA:
-			if (mediaId == null || mediaId.isEmpty()) {
-				throw new IllegalArgumentException("mediaId cannot be null or empty.");
-			}
-			break;
-		case MESSAGE:
-			if (message == null || message.isEmpty()) {
-				throw new IllegalArgumentException("message cannot be null or empty.");
-			}
-			break;
-		default:
-			break;
-		}
-	}
+    protected String buildBody(List<Map<String, String>> bodies, String boundary) {
+        StringBuilder sb = new StringBuilder();
+        String newLine = "\r\n";
+        for (Map<String, String> b : bodies) {
+            sb.append("--").append(boundary).append(newLine).append("Content-Disposition: ").append(b.get("type"))
+                    .append("; name=\"").append(b.get("name")).append("\"").append(newLine).append(newLine)
+                    .append(b.get("data")).append(newLine);
+        }
+        sb.append("--").append(boundary).append("--");
+        String body = sb.toString();
 
-	public static Builder builder(ShareType shareType) {
-		Builder b = new Builder();
-		b.shareType(shareType);
-		return b;
-	}
-	
-	public static Builder builder(ShareType shareType, List<String> recipients) {
-		Builder b = new Builder();
-		b.shareType(shareType).recipients(recipients);
-		return b;
-	}
+        log.debug("Direct-share message body: " + body);
+        return body;
+    }
 
-	public static class Builder extends DirectShareRequestBuilder {
-		Builder() {
-			super();
-		}
+    protected void init() {
+        switch (shareType) {
+            case MEDIA:
+                if (mediaId == null || mediaId.isEmpty()) {
+                    throw new IllegalArgumentException("mediaId cannot be null or empty.");
+                }
+                break;
+            case MESSAGE:
+                if (message == null || message.isEmpty()) {
+                    throw new IllegalArgumentException("message cannot be null or empty.");
+                }
+                break;
+            case LINK:
+                // can link_text be null/empty?
+                if (link_urls == null || link_urls.size() == 0) {
+                    throw new IllegalArgumentException("link url cannot be empty");
+                }
+                break;
+            default:
+                break;
+        }
+    }
 
-		@Override
-		public InstagramDirectShareRequest build() {
-			InstagramDirectShareRequest i = super.build();
-			i.init();
-			return i;
-		}
-	}
+    public static Builder builder(ShareType shareType) {
+        Builder b = new Builder();
+        b.shareType(shareType);
+        return b;
+    }
 
-	public enum ShareType {
-		MESSAGE, MEDIA
-	}
+    public static Builder builder(ShareType shareType, List<String> recipients) {
+        Builder b = new Builder();
+        b.shareType(shareType).recipients(recipients);
+        return b;
+    }
+
+    public static class Builder extends DirectShareRequestBuilder {
+        Builder() {
+            super();
+        }
+
+        @Override
+        public InstagramDirectShareRequest build() {
+            InstagramDirectShareRequest i = super.build();
+            i.init();
+            return i;
+        }
+    }
+
+    public enum ShareType {
+        MESSAGE, MEDIA, LINK, PHOTO
+    }
 }

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetPendingInboxRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetPendingInboxRequest.java
@@ -1,0 +1,42 @@
+package org.brunocvcunha.instagram4j.requests;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.brunocvcunha.instagram4j.requests.payload.InstagramPendingInboxResult;
+
+/**
+ * Request to fetch "hidden" instagram inbox containing pending direct messages.
+ * Messages from users you do not follow get sent here for the first time
+ * Note that {@link org.brunocvcunha.instagram4j.requests.payload.InstagramInboxResult#pending_requests_total} already shows how many messages are in this pending inbox, 0 if none
+ *
+ * @author Willy Hille
+ */
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class InstagramGetPendingInboxRequest extends InstagramGetRequest<InstagramPendingInboxResult> {
+
+    private String cursor;
+
+    @Override
+    public String getUrl() {
+
+        String baseUrl = "direct_v2/pending_inbox/?";
+        if (cursor != null && !cursor.isEmpty()) {
+            baseUrl += "&cursor=" + cursor;
+        }
+        return baseUrl;
+    }
+
+    @Override
+    @SneakyThrows
+    public String getPayload() {
+        return null;
+    }
+
+    @Override
+    @SneakyThrows
+    public InstagramPendingInboxResult parseResult(int statusCode, String content) {
+        return parseJson(statusCode, content, InstagramPendingInboxResult.class);
+    }
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/DirectLink.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/DirectLink.java
@@ -1,0 +1,18 @@
+package org.brunocvcunha.instagram4j.requests.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * support receiving links in direct messages
+ * @author Willy Hille
+ */
+@Getter
+@Setter
+@ToString
+public class DirectLink {
+
+    public String text;
+    public LinkContext link_context;
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadItem.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadItem.java
@@ -37,4 +37,5 @@ public class InstagramInboxThreadItem {
 	public String like;
 	public String text;
 	public InstagramInboxThreadReel reel_share;
+	public InstagramFeedItem media_share;
 }

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadItem.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadItem.java
@@ -39,4 +39,5 @@ public class InstagramInboxThreadItem {
 	public InstagramInboxThreadReel reel_share;
 	public InstagramFeedItem media_share;
 	public StoryShare story_share;
+	public DirectLink link;
 }

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadItem.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramInboxThreadItem.java
@@ -38,4 +38,5 @@ public class InstagramInboxThreadItem {
 	public String text;
 	public InstagramInboxThreadReel reel_share;
 	public InstagramFeedItem media_share;
+	public StoryShare story_share;
 }

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramPendingInboxResult.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramPendingInboxResult.java
@@ -1,0 +1,20 @@
+package org.brunocvcunha.instagram4j.requests.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Result object for the "hidden" instagram inbox containing pending direct messages
+ *
+ * @author Willy Hille
+ */
+@Getter
+@Setter
+@ToString(callSuper = true)
+public class InstagramPendingInboxResult extends StatusResult {
+
+    public String seq_id;
+    public int pending_requests_total;
+    public InstagramInbox inbox;
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/LinkContext.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/LinkContext.java
@@ -1,0 +1,20 @@
+package org.brunocvcunha.instagram4j.requests.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * support receiving links in direct messages
+ * @author Willy Hille
+ */
+@Getter
+@Setter
+@ToString
+public class LinkContext {
+
+    public String link_url;
+    public String link_title;
+    public String link_summary;
+    public String link_image_url;
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/StoryShare.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/StoryShare.java
@@ -1,0 +1,21 @@
+package org.brunocvcunha.instagram4j.requests.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * story_share for direct messages
+ * @author Willy Hille
+ */
+@Getter
+@Setter
+@ToString
+public class StoryShare {
+
+    public InstagramFeedItem media;
+    public String text;
+    public String title;
+    public String message;
+    public boolean is_linked;
+}


### PR DESCRIPTION
I added the `media_share `and `story_share` properties to `InstagramInboxThreadItem`.
The `StoryShare` model is copied from [the PHP library](https://github.com/mgp25/Instagram-API/blob/master/src/Response/Model/StoryShare.php). I hope I put it in the right place.

During testing I noticed that `StoryShare.title` and `StoryShare.message` are always null, `StoryShare.text` is empty but not null. As I've said I *do not* know if the API even supports those tags even if the PHP lib has them. Question: should we remove those properties to prevent confusion?

Possible next steps are further adding properties to `InstagramInboxThreadItem` from [DirectThreadItem.php](https://github.com/mgp25/Instagram-API/blob/master/src/Response/Model/DirectThreadItem.php) and rethinking the way `story_share` works inside of the library. It looks like a normally posted image to the library but some properties may be different.
One final less important thing to note is that you *can* actually take the postcode of a story and make it into an instagram url (the /p/ thing) and look at it. I didn't know that was a thing.
Example: You can view the latest story (as of now) by [this account](https://www.instagram.com/thebestsocialmediade/) via [this link](https://www.instagram.com/p/BvHCdurg8Sj/) and still get the normal post view for it.