### PR TITLE
[Feature] Approve or Reject friendship pending requests

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramApproveFriendshipRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramApproveFriendshipRequest.java
@@ -1,0 +1,54 @@
+package org.brunocvcunha.instagram4j.requests;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.brunocvcunha.instagram4j.requests.payload.InstagramFriendshipResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+
+/**
+ * {@link InstagramApproveFriendshipRequest} send a post request to approve a pending request of a certain user
+ * 
+ * @author Daniele Pancottini
+ *
+ */
+
+@AllArgsConstructor
+public class InstagramApproveFriendshipRequest extends InstagramPostRequest<InstagramFriendshipResult> {
+
+	@NonNull
+	private Long userId;
+
+	@Override
+	public String getUrl() {
+		return "friendships/approve/" + userId + "/";
+	}
+
+	@Override
+    @SneakyThrows
+    public String getPayload() {
+        ObjectMapper mapper = new ObjectMapper();
+        
+        Map<String, Object> payloadMap = new LinkedHashMap<>();
+        payloadMap.put("_uuid", api.getUuid());
+        payloadMap.put("_uid", api.getUserId());
+        payloadMap.put("user_id", this.userId);
+        payloadMap.put("radio_type", "wifi-none");
+        payloadMap.put("_csrftoken", api.getOrFetchCsrf());
+        
+        String payloadJson = mapper.writeValueAsString(payloadMap);
+
+        return payloadJson;
+    }
+	
+	@Override
+	public InstagramFriendshipResult parseResult(int resultCode, String content) {
+		return parseJson(resultCode, content, InstagramFriendshipResult.class);
+	}
+	
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetPendingFriendshipsRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramGetPendingFriendshipsRequest.java
@@ -1,0 +1,29 @@
+package org.brunocvcunha.instagram4j.requests;
+
+import org.brunocvcunha.instagram4j.requests.payload.InstagramGetPendingFriendshipsResult;
+
+import lombok.SneakyThrows;
+
+/**
+ * {@link InstagramGetPendingFriendshipsRequest} return a list of pending firensdhip requests
+ * 
+ * @author Daniele Pancottini
+ *
+ */
+
+public class InstagramGetPendingFriendshipsRequest extends InstagramGetRequest<InstagramGetPendingFriendshipsResult> {
+
+	@Override
+	public String getUrl() {
+		return "friendships/pending/";
+	}
+
+	@Override
+	@SneakyThrows
+	public InstagramGetPendingFriendshipsResult parseResult(int resultCode, String content) {
+		return parseJson(resultCode, content, InstagramGetPendingFriendshipsResult.class);
+	}
+
+	
+	
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramRejectFriendshipRequest.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/InstagramRejectFriendshipRequest.java
@@ -1,0 +1,59 @@
+package org.brunocvcunha.instagram4j.requests;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.brunocvcunha.instagram4j.requests.payload.InstagramFriendshipResult;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.SneakyThrows;
+
+/**
+ * 
+ * {@link InstagramRejectFriendshipRequest} exec a post request to reject a friendship pending request of a certain user
+ * 
+ * @author Daniele Pancottini
+ *
+ */
+
+@AllArgsConstructor
+public class InstagramRejectFriendshipRequest extends InstagramPostRequest<InstagramFriendshipResult> {
+
+	@NonNull
+	private Long userId;
+	
+	@Override
+	public String getUrl() {
+		return "friendships/ignore/" + userId + "/";
+	}
+	
+	@Override
+	@SneakyThrows
+	public String getPayload() {
+		
+		ObjectMapper mapper = new ObjectMapper();
+        
+        Map<String, Object> payloadMap = new LinkedHashMap<>();
+        payloadMap.put("_uuid", api.getUuid());
+        payloadMap.put("_uid", api.getUserId());
+        payloadMap.put("user_id", this.userId);
+        payloadMap.put("radio_type", "wifi-none");
+        payloadMap.put("_csrftoken", api.getOrFetchCsrf());
+        
+        String payloadJson = mapper.writeValueAsString(payloadMap);
+
+        return payloadJson;
+        
+	}
+
+	@Override
+	public InstagramFriendshipResult parseResult(int resultCode, String content) {
+		return parseJson(resultCode, content, InstagramFriendshipResult.class);
+	}
+
+	
+	
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramFriendshipResult.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramFriendshipResult.java
@@ -1,0 +1,21 @@
+package org.brunocvcunha.instagram4j.requests.payload;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**
+ * Instagram friendship response, at the moment used only as approve/reject requests result
+ * 
+ * @author Daniele Pancottini
+ *
+ */
+
+@Getter
+@Setter
+@ToString(callSuper = true)
+public class InstagramFriendshipResult extends StatusResult {
+
+	public InstagramFriendshipStatus friendship_status;
+	
+}

--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramGetPendingFriendshipsResult.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramGetPendingFriendshipsResult.java
@@ -1,0 +1,35 @@
+package org.brunocvcunha.instagram4j.requests.payload;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+/**ù
+ *	Get pending friendships result
+ *
+ * @author Daniele Pancottini
+ *
+ */
+
+@Getter
+@Setter
+@ToString(callSuper = true)
+public class InstagramGetPendingFriendshipsResult extends StatusResult {
+
+	
+	public List<InstagramUser> users;
+	public int truncate_follow_requests_at_index;
+	public String next_max_id;
+	
+	/*
+	  	fields not necessary to response
+	 
+		public InstagramSuggestedUsers suggested_users;
+		public int page_size;
+		public int big_list;
+		
+	 */
+	 
+}


### PR DESCRIPTION
- Added InstagramGetPendingFriendshipsRequest to get all pending request of current logged user
- Added InstagramApproveFriendshipRequest to approve a request of a
certain user
- Added InstagramRejectFriendshipRequest to reject a request of a
certain user

Fixes #299 

Little example about how to use my code
```
public static void main(String args[]) {
		
		try {
			
			Instagram4j instagram = Instagram4j.builder().username("xxxxx").password("xxxx").build();
			instagram.setup();
			instagram.login();
			
			InstagramGetPendingFriendshipsResult pendingReq = instagram.sendRequest(new InstagramGetPendingFriendshipsRequest());
			
			for(InstagramUser x : pendingReq.getUsers()) {
				instagram.sendRequest(new InstagramApproveFriendshipRequest(x.getPk())); //InstagramRejectFriendshipRequest to reject a request
			}
			
		}
		catch(Exception e) {
			e.printStackTrace();
		}
		
	}
```