### PR TITLE
Use openjdk8 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 
 install: ./mvnw clean install -q
 


### PR DESCRIPTION
It seems oraclejdk8 can no longer be used and is causing build failure. This PR changes .travis.yml to use openjdk8