### PR TITLE
[Feature] Added ability to get comment like count

### DIFF
--- a/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramComment.java
+++ b/src/main/java/org/brunocvcunha/instagram4j/requests/payload/InstagramComment.java
@@ -40,4 +40,5 @@ public class InstagramComment {
 	private boolean did_report_as_spam;
 	private boolean share_enabled;
 	private long media_id;
+	private int comment_like_count;
 }


### PR DESCRIPTION
Added `comment_like_count` attribute to `InstagramComment`

Closes #365 
Closes #92 (old issue)